### PR TITLE
feature: limit slack search to ALLOWED_CHANNELS

### DIFF
--- a/slack/provider/app.py
+++ b/slack/provider/app.py
@@ -7,10 +7,19 @@ from . import UpstreamProviderError, provider
 
 logger = logging.getLogger(__name__)
 
+ALLOWED_CHANNELS: list[str] = [
+    "sig-memes-and-nonsense"
+]
+
+
+def _format_query(original_query: str, allowed_channels: list[str]) -> str:
+    return " ".join(f"in:{channel}" for channel in allowed_channels) + " " + original_query
+
 
 def search(body):
     try:
-        data = provider.search(body["query"])
+        query = _format_query(body["query"], ALLOWED_CHANNELS)
+        data = provider.search(query)
         logger.info(f"Found {len(data)} results")
     except UpstreamProviderError as error:
         logger.error(f"Upstream search error: {error.message}")


### PR DESCRIPTION
Limit slack connector access to search only in channels listed in `ALLOWED_CHANNELS`

NB this is for proof of concept work only, the actual connector will be quite useless with this change! 